### PR TITLE
Add regex processing to positive/negative lists

### DIFF
--- a/reddit_io.py
+++ b/reddit_io.py
@@ -250,12 +250,12 @@ class RedditIO(threading.Thread, LogicMixin):
 
 	def _positive_keyword_matches(self, text):
 		if self._positive_keywords:
-			return [keyword for keyword in self._positive_keywords if keyword in text]
+			return [keyword for keyword in self._positive_keywords if re.search(r"\b{}\b".format(keyword), text, re.IGNORECASE)]
 		return []
 
 	def _negative_keyword_matches(self, text):
 		if self._negative_keywords:
-			return [keyword for keyword in self._negative_keywords if keyword in text]
+			return [keyword for keyword in self._negative_keywords if re.search(r"\b{}\b".format(keyword), text, re.IGNORECASE)]
 		return []
 
 


### PR DESCRIPTION
This change allows regex processing to be used when identifying posivite/negative phrases in the text generation. In addition to regex, it will eliminate some false-positives (like finding"ass" in "thassalophobia"