### PR TITLE
Fix download script not downloading all possible data, make output more user-friendly

### DIFF
--- a/model_finetuning/dataset_template.ini
+++ b/model_finetuning/dataset_template.ini
@@ -18,3 +18,6 @@ submission_limit=100
 ; OPTIONAL, a comma separated list of keywords. If these words are found in a reddit comment, the comment is ignored
 ; Feeding a lot of finetuning data usually makes this unneccesary
 negative_keywords=
+
+; OPTIONAL, set to 'True' to display more text output when executing the download script
+verbose=

--- a/model_finetuning/dataset_template.ini
+++ b/model_finetuning/dataset_template.ini
@@ -19,5 +19,5 @@ submission_limit=100
 ; Feeding a lot of finetuning data usually makes this unneccesary
 negative_keywords=
 
-; OPTIONAL, set to 'True' to display more text output when executing the download script
+; OPTIONAL, set to 'True' to display more detailed text output when running the download script
 verbose=

--- a/model_finetuning/download_reddit_finetuning_data.py
+++ b/model_finetuning/download_reddit_finetuning_data.py
@@ -22,7 +22,7 @@ config.read('dataset.ini')
 verbose = False
 
 if config['DEFAULT']['verbose']:
-	verbose = config['DEFAULT']['verbose'] == 'True'
+	verbose = config['DEFAULT'].getboolean('verbose')
 
 def loop_between_dates(start_datetime, end_datetime):
 	# yields start and end dates between the dates given


### PR DESCRIPTION
Currently, the script simply skips the current download if the response code is not 200. This is an issue when we're being ratelimited by pushshift (error 429), and I've updated it to wait and extra 400ms and re-attempt the request up to 3 times in a row before actually giving up and moving on (for both submissions and comments). In my testing this seems to have remedied the problem and all possible data is being downloaded in the range I give it. 

I also tried to improve readability of the output by making it display the date range that is currently being downloaded, as well as an overall percentage to completion. The usual verbose output can be turned back on by setting `verbose=True` in the dataset.ini.

Also removed a seemingly unused `counter` variable from the `write_to_database` function. If this was planned to be used it can be re-added.

Addresses #27 