### PR TITLE
add dataset config option for negative users

### DIFF
--- a/model_finetuning/dataset_template.ini
+++ b/model_finetuning/dataset_template.ini
@@ -19,5 +19,9 @@ submission_limit=100
 ; Feeding a lot of finetuning data usually makes this unneccesary
 negative_keywords=
 
+; OPTIONAL, a comma separated list of users. If a comment is found to be created by this user, it will be discarded.
+; Appended to the default list in output_finetuning_data.py
+negative_users=
+
 ; OPTIONAL, set to 'True' to display more detailed text output when running the download script
 verbose=

--- a/model_finetuning/output_finetuning_data.py
+++ b/model_finetuning/output_finetuning_data.py
@@ -55,6 +55,9 @@ author_list = [
 	'YoMammaJokebot', 'youtubefactsbot', 'YTubeInfoBot'
 	]
 
+if config['DEFAULT']['negative_users']:
+    author_list += config['DEFAULT']['negative_users'].split(",")
+
 lowercase_author_list = [a.lower() for a in author_list]
 
 from utils.keyword_helper import KeywordHelper


### PR DESCRIPTION
see example:
```ini
; OPTIONAL, a comma separated list of users. If a comment is found to be created by this user, it will be discarded.
; Appended to the default list in output_finetuning_data.py
negative_users=
```
i'm not too sure of `negative_users` being the key, but I couldn't think of anything better.